### PR TITLE
fix issue #9

### DIFF
--- a/src/common/WikiConnector.ts
+++ b/src/common/WikiConnector.ts
@@ -241,7 +241,12 @@ export class WikiConnector {
 
     private async getToken(): Promise<void> {
         const response = await this.callApi<TokenResponse>("action=query&meta=tokens&type=csrf");
-        this.csrf = response.query.tokens.csrftoken;
+        const token = response.query.tokens.csrftoken;
+        if (token !== "\\+") {  // work around the API endpoint returning \+ instead of failure when no login
+            this.csrf = token;
+        } else {
+            this.csrf = undefined;
+        }
     }
     /*
 


### PR DESCRIPTION
This fix for issue #9 works around the API returning a blank csrf token when the user is not logged in.

This token would previously have been used, and be subsequently accepted by the API for marker completion requests, which resulted in data loss.

The patch sets the csrf token to `undefined` when the string `"\+"` (the blank token) is returned by the API endpoint. This results in the string `"undefined"` being encoded in subsequent requests, which (correctly) fail with the `badtoken` status code.