### PR TITLE
Draft: Change pin message format to enable copy/pasting to category page

### DIFF
--- a/src/common/ZDMap.ts
+++ b/src/common/ZDMap.ts
@@ -140,10 +140,23 @@ export class ZDMap extends Map {
         tempMarker
           .setLatLng(e.latlng)
           .addTo(map)
+          // Pin template: {"coords":[<x>,<y>],"elv":"<z>","id":"<nameXX>","name":"<name>","link":"<name>"}
           .setPopupContent(
-            `{{Pin|${Math.round(e.latlng.lng)}|${Math.round(
-              e.latlng.lat
-            )}||&lt;name&gt;}}<br />${wikiContributeLink}`
+            "Coordinates: " +
+              Math.round(e.latlng.lng) +
+              ", " +
+              Math.round(e.latlng.lat) +
+              ", 0" +
+              "<br/>" +
+              "Dev:" +
+              "<br/>" +
+              '{"coords":[' +
+              Math.round(e.latlng.lat) +
+              "," +
+              Math.round(e.latlng.lng) +
+              '],"elv":"0","id":"&lt;name&gt;","name":"&lt;name00&gt","link":"&lt;name&gt"}' +
+              "<br />" +
+              wikiContributeLink
           )
           .openPopup();
       }


### PR DESCRIPTION
Change the pin message format such that editors can simply copy paste the community pins into the[ category page](https://www.zeldadungeon.net/wiki/Zelda_Dungeon:Tears_of_the_Kingdom_Map/Surface_Categories).

- [ ] Also need to change the wiki import functions to support the new format
- [ ] Change wiki guide to contributing

Python script to convert already existing user submissions to the proper format:
```
fr = open("zelda_dungeon_pins.txt", "r")
fw = open("zelda_dungeon_pins.json", "w")
for l in fr:
    x = l.split("|")[2]
    y = l.split("|")[1]
    z = l.split("|")[3]
    name = l.split("|")[4].split("}}")[0]
    fw.write("{\"coords\":[" + x + "," + y + "],\"elv\":\"" + z + "\",\"id\":\"" +
             name + "00\",\"name\":\"" + name + "\",\"link\":\"" + name + "\"}\n")
```