### PR TITLE
fix layerEnabled icon on initial load

### DIFF
--- a/src/common/LayersControl.ts
+++ b/src/common/LayersControl.ts
@@ -44,6 +44,10 @@ export class LayersControl extends Control {
       );
 
       this.layers.push({ layer, button });
+      //Check whether this layer is currently visible, if so select it
+      if (layer.hasLayer(layer.tileLayer)) {
+        this.selectLayer(layer.layerName);
+      }
     }
   }
 


### PR DESCRIPTION
The layerEnabled icon now shows on initial page load.
![image](https://github.com/zeldadungeon/maps/assets/24990129/1ee6ce5e-ba0d-4a46-9f8e-df6a065fbe8c)
