### PR TITLE
[fix #59] add center class for parsed wiki content

### DIFF
--- a/src/common/style.scss
+++ b/src/common/style.scss
@@ -595,3 +595,13 @@ body {
 .zd-popup__footer {
   margin-bottom: 0.5em;
 }
+
+/* WIKI CONTENT */
+.center {
+  width: 100%;
+  text-align: center;
+}
+*.center * {
+  margin-left: auto;
+  margin-right: auto;
+}


### PR DESCRIPTION
Fixes https://github.com/zeldadungeon/maps/issues/59

# Summary

The response from the wiki api contains a div with class center. I grabbed the exact css from the wiki page and added it here

# Testing

I had to locally mock a response because of the CORS issue, so I got halfway there. I can confirm the css is being applied

## Before
![image](https://github.com/zeldadungeon/maps/assets/74829867/b001d980-89d9-4116-942a-d62f8d116d6f)

## After
![image](https://github.com/zeldadungeon/maps/assets/74829867/fecd9a3d-e72a-4d91-ae63-cd1dc9d4c812)
