### PR TITLE
[resolve #66] make contribution marker a toggleable handler

### DIFF
--- a/src/common/Handlers/ContributionMarkerHandler.ts
+++ b/src/common/Handlers/ContributionMarkerHandler.ts
@@ -42,7 +42,6 @@ export class ContributionMarkerHandler extends ZDHandler {
   }
 
   private displayMarker(e: LeafletMouseEvent) {
-    console.log("display marker");
     this.setPopupContent(e.latlng);
     this.contributionMarker.setLatLng(e.latlng).addTo(this.map).openPopup();
   }

--- a/src/common/Handlers/ContributionMarkerHandler.ts
+++ b/src/common/Handlers/ContributionMarkerHandler.ts
@@ -1,0 +1,59 @@
+import { LatLng, LeafletMouseEvent, Marker } from "leaflet";
+import markerIconUrl from "leaflet/dist/images/marker-icon.png";
+import markerIconRetinaUrl from "leaflet/dist/images/marker-icon-2x.png";
+import markerShadowUrl from "leaflet/dist/images/marker-shadow.png";
+import { ZDMap, ZDMapOptions } from "common/ZDMap";
+import { ZDHandler } from "./ZDHandler";
+
+export class ContributionMarkerHandler extends ZDHandler {
+  name = "Contribution Marker";
+  private contributionMarker = new Marker([0, 0], {
+    draggable: true,
+  }).bindPopup("");
+  constructor(protected map: ZDMap, private zdMapOptions: ZDMapOptions) {
+    super(map);
+    if (import.meta.env.PROD) {
+      // Fix Vite not resolving icon url from node_modules/leaflet/dist
+      this.contributionMarker.getIcon().options.iconUrl = markerIconUrl;
+      this.contributionMarker.getIcon().options.iconRetinaUrl =
+        markerIconRetinaUrl;
+      this.contributionMarker.getIcon().options.shadowUrl = markerShadowUrl;
+    }
+  }
+  addHooks(): void {
+    this.map.on("click", this.displayMarker, this);
+    this.contributionMarker.on("drag", this.dragMarker, this);
+    this.contributionMarker.on("click", this.removeMarker, this);
+  }
+  removeHooks(): void {
+    this.map.off("click", this.displayMarker, this);
+    this.contributionMarker.off("drag", this.dragMarker, this);
+    this.contributionMarker.off("click", this.removeMarker, this);
+    this.removeMarker();
+  }
+
+  private setPopupContent(latlng: LatLng) {
+    const wikiContributeLink = `<a target="_blank" href="https://zeldadungeon.net/wiki/Zelda Dungeon:${this.zdMapOptions.gameTitle} Map">Contribute Marker</a>`;
+    this.contributionMarker.setPopupContent(
+      `{{Pin|${Math.round(latlng.lng)}|${Math.round(
+        latlng.lat
+      )}||&lt;name&gt;}}<br />${wikiContributeLink}<br /><br />Contribution Marker can be<br />disabled in the Settings`
+    );
+  }
+
+  private displayMarker(e: LeafletMouseEvent) {
+    console.log("display marker");
+    this.setPopupContent(e.latlng);
+    this.contributionMarker.setLatLng(e.latlng).addTo(this.map).openPopup();
+  }
+
+  private dragMarker() {
+    const latlng = this.contributionMarker.getLatLng();
+    this.setPopupContent(latlng);
+    this.contributionMarker.openPopup();
+  }
+
+  private removeMarker() {
+    this.contributionMarker.removeFrom(this.map);
+  }
+}

--- a/src/common/Handlers/ContributionMarkerHandler.ts
+++ b/src/common/Handlers/ContributionMarkerHandler.ts
@@ -11,7 +11,7 @@ export class ContributionMarkerHandler extends ZDHandler {
     draggable: true,
   }).bindPopup("");
   constructor(protected map: ZDMap, private zdMapOptions: ZDMapOptions) {
-    super(map);
+    super();
     if (import.meta.env.PROD) {
       // Fix Vite not resolving icon url from node_modules/leaflet/dist
       this.contributionMarker.getIcon().options.iconUrl = markerIconUrl;

--- a/src/common/Handlers/ZDHandler.ts
+++ b/src/common/Handlers/ZDHandler.ts
@@ -1,0 +1,33 @@
+import { ZDMap } from "common/ZDMap";
+
+// inspired by Leaflet's Handler, but using a TypeScipt-friendly ES6 class
+export abstract class ZDHandler {
+  private _enabled: boolean;
+  abstract name: string;
+  constructor(protected map: ZDMap) {
+    this._enabled = false;
+  }
+  enable() {
+    if (this._enabled) {
+      return this;
+    }
+
+    this._enabled = true;
+    this.addHooks();
+    return this;
+  }
+
+  disable() {
+    if (!this._enabled) {
+      return this;
+    }
+
+    this._enabled = false;
+    this.removeHooks();
+    return this;
+  }
+
+  abstract addHooks(): void;
+
+  abstract removeHooks(): void;
+}

--- a/src/common/Handlers/ZDHandler.ts
+++ b/src/common/Handlers/ZDHandler.ts
@@ -1,10 +1,8 @@
-import { ZDMap } from "common/ZDMap";
-
 // inspired by Leaflet's Handler, but using a TypeScipt-friendly ES6 class
 export abstract class ZDHandler {
   private _enabled: boolean;
   abstract name: string;
-  constructor(protected map: ZDMap) {
+  constructor() {
     this._enabled = false;
   }
   enable() {

--- a/src/totk.ts
+++ b/src/totk.ts
@@ -3,7 +3,8 @@ import * as Schema from "./common/JSONSchema";
 import { ICategory } from "./common/ICategory";
 import { Layer } from "./common/Layer";
 import { MapLayer } from "./common/MapLayer";
-import { ZDMap } from "./common/ZDMap";
+import { ZDMap, ZDMapOptions } from "./common/ZDMap";
+import { ContributionMarkerHandler } from "./common/Handlers/ContributionMarkerHandler";
 
 window.onload = async () => {
   function legendItem(
@@ -32,14 +33,16 @@ window.onload = async () => {
     };
   }
 
-  const map = ZDMap.create({
+  const options: ZDMapOptions = {
     directory: "totk",
     gameTitle: "Tears of the Kingdom",
     mapSizePixels: 36096,
     mapSizeCoords: 12032,
     tileSizePixels: 564,
     center: [101, -255],
-  });
+  };
+
+  const map = ZDMap.create(options);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const sky = map.addMapLayer("Sky", "sky", "sky-selected", false);
   const surface = map.addMapLayer(
@@ -476,7 +479,8 @@ window.onload = async () => {
           },
         ],
       },
-    ]
+    ],
+    [new ContributionMarkerHandler(map, options)]
   );
   map.addLegend(
     [


### PR DESCRIPTION
# Summary

Resolves https://github.com/zeldadungeon/maps/issues/66

## ZDHandler

Introduce abstract class `ZDHandler`, very similar to Leaflet's [Handler](https://leafletjs.com/reference.html#handler), meant to be [extended](https://leafletjs.com/examples/extending/extending-3-controls.html) in a similar fashion. Unlike Leaflet, this uses ES6 Class inheritance rather than the extremely janky `.extend` nonsense they use.

This could be further utilized to make other behaviors toggleable, e.g. the on click handler which pans the map. New behaviors and also be off by default, i.e. be opt-in.

### Demo Conceptual Screenshot
This should demonstrate the idea. This is a non-committed change to the BotW map that adds two generic handlers, A and B. As they are toggled, all they do is log a message.

![image](https://github.com/zeldadungeon/maps/assets/74829867/05fb83b1-72da-46d3-b9e2-09af9edf39f1)

## Contribution Marker Handler
Extending `ZDHandler`, introduce `ContributionMarkerHandler` which governs the behavior of the Contribution Marker currently on the TotK map. This diff keeps it on by default, but a one-line change could make it off by default.

Add note about disabling contribution marker to the marker's popup.

## Miscellaneous
Refactor settings row DOM creation code to be reusable for handlers.

# Testing

## Regression Checks
- Ensure other maps (e.g. BotW) do not acquire the handler.
- Ensure other maps keep the `panTo` click handler.
- Ensure existing persisted settings are respected
- Ensure Completed markers are hidden by default
- Ensure Contribution Marker is on by default for TotK.

## New Functionality
- Ensure disabling contribution marker hides any visible marker.
- Ensure re-enabling contribution marker does _not_ bring back a marker that was hidden in prior test.
- Ensure the marker no longer shows up when contribution marker is disabled
- Ensure toggling the enablement does not remove the `panTo` click handler.

## Screenshots

### BotW Unaffected

![botw-unaffected](https://github.com/zeldadungeon/maps/assets/74829867/26585029-be55-4cda-adce-0adaaa6f7772)

### TotK Settings

![totk-contribution-marker](https://github.com/zeldadungeon/maps/assets/74829867/3e8fb96b-c95c-460a-9b14-2e8af3012e20)



