### PR TITLE
catch initializeWikiConnector rejection

### DIFF
--- a/src/totk.ts
+++ b/src/totk.ts
@@ -710,7 +710,7 @@ window.onload = async () => {
     addWiki(depths, "Wiki", "Depths Markers", "temp", "flag", 25, 28, 2),
   ]);
 
-  await map.initializeWikiConnector();
+  await map.initializeWikiConnector().catch((ex) => console.log(ex));
 
   await Promise.allSettled([
     addObjects(surface, "surface/materials.json"),


### PR DESCRIPTION
# Summary
While developing locally, initializeWikiConnector rejects/throws, which causes the subsequent lines adding materials.json objects to not run

With this catch, the error is logged and the materials are added

# Testing
Error is logged and materials are available