### PR TITLE
[fix #80] add controls position setting

### DIFF
--- a/src/common/Controls/ControlDock.ts
+++ b/src/common/Controls/ControlDock.ts
@@ -1,4 +1,4 @@
-import { Control, DomEvent, DomUtil } from "leaflet";
+import { Control, ControlPosition, DomEvent, DomUtil } from "leaflet";
 import { ControlPane } from "./ControlPane";
 import { LayersControl } from "./LayersControl";
 import { LocalStorage } from "../LocalStorage";
@@ -9,6 +9,7 @@ import { ZoomControl } from "./ZoomControl";
  */
 export class ControlDock extends Control {
   private container: HTMLElement;
+  private dock: HTMLElement;
   private group1: HTMLElement;
   private group2: HTMLElement;
   private group3: HTMLElement;
@@ -21,10 +22,10 @@ export class ControlDock extends Control {
     });
 
     this.container = DomUtil.create("aside", "zd-controls");
-    const dock = DomUtil.create("div", "zd-controls__dock", this.container);
-    this.group1 = DomUtil.create("div", "zd-controls__dock__group", dock);
-    this.group2 = DomUtil.create("div", "zd-controls__dock__group", dock);
-    this.group3 = DomUtil.create("div", "zd-controls__dock__group", dock);
+    this.dock = DomUtil.create("div", "zd-controls__dock", this.container);
+    this.group1 = DomUtil.create("div", "zd-controls__dock__group", this.dock);
+    this.group2 = DomUtil.create("div", "zd-controls__dock__group", this.dock);
+    this.group3 = DomUtil.create("div", "zd-controls__dock__group", this.dock);
     this.paneContainer = DomUtil.create(
       "div",
       "zd-controls__pane-container",
@@ -77,6 +78,22 @@ export class ControlDock extends Control {
 
   public addZoom(zoom: ZoomControl): void {
     this.group2.appendChild(zoom.getButtons());
+  }
+
+  // @override
+  public setPosition(position: ControlPosition): this {
+    super.setPosition(position);
+    switch (position) {
+      case "bottomleft":
+      case "topleft":
+        this.container.insertBefore(this.dock, this.paneContainer);
+        break;
+      case "bottomright":
+      case "topright":
+        this.container.insertBefore(this.paneContainer, this.dock);
+        break;
+    }
+    return this;
   }
 
   private showControl(control: ControlPane): void {

--- a/src/common/Controls/SettingsControl.ts
+++ b/src/common/Controls/SettingsControl.ts
@@ -1,5 +1,6 @@
 import { DomEvent, DomUtil } from "leaflet";
 import { ControlPane } from "./ControlPane";
+import { ControlDock } from "./ControlDock";
 import { WikiConnector } from "../WikiConnector";
 import { MapLayer } from "../MapLayer";
 import { LocalStorage } from "../LocalStorage";
@@ -19,6 +20,7 @@ type ToggleableSettingsRowConfig = {
   offByDefault: boolean;
   handleToggleOn: () => void;
   handleToggleOff: () => void;
+  toggleOffOnLoadFalse: boolean;
 };
 function createToggleableSettingsRow({
   settingsContent,
@@ -30,6 +32,7 @@ function createToggleableSettingsRow({
   offByDefault,
   handleToggleOn,
   handleToggleOff,
+  toggleOffOnLoadFalse,
 }: ToggleableSettingsRowConfig) {
   const row = DomUtil.create("tr", "zd-settings__setting", settingsContent);
   const on = DomUtil.create("td", "zd-settings__button selectable", row);
@@ -40,6 +43,9 @@ function createToggleableSettingsRow({
   label.innerText = tag;
 
   const settingValue = settingsStore.getItem<boolean>(settingsStoreKey);
+  if (settingValue === false && toggleOffOnLoadFalse) {
+    handleToggleOff();
+  }
   if (settingValue === false || (offByDefault && settingValue !== true)) {
     DomUtil.addClass(off, "selected");
   } else {
@@ -76,7 +82,8 @@ export class SettingsControl extends ControlPane {
     settingsStore: LocalStorage,
     layers: MapLayer[],
     tags: string[],
-    handlers: ZDHandler[]
+    handlers: ZDHandler[],
+    controls: ControlDock
   ) {
     super({
       icon: "fa-cog",
@@ -119,6 +126,7 @@ export class SettingsControl extends ControlPane {
         offByDefault: tag === "Completed",
         handleToggleOn,
         handleToggleOff,
+        toggleOffOnLoadFalse: false,
       });
     });
 
@@ -135,7 +143,20 @@ export class SettingsControl extends ControlPane {
         offByDefault: false,
         handleToggleOn,
         handleToggleOff,
+        toggleOffOnLoadFalse: false,
       });
+    });
+    createToggleableSettingsRow({
+      settingsContent,
+      onText: "Left",
+      offText: "Right",
+      tag: "Controls Position",
+      settingsStore,
+      settingsStoreKey: "controls-on-left",
+      offByDefault: false,
+      handleToggleOn: () => controls.setPosition("bottomleft"),
+      handleToggleOff: () => controls.setPosition("bottomright"),
+      toggleOffOnLoadFalse: true,
     });
     const clearCompletionDataRow = DomUtil.create(
       "tr",

--- a/src/common/ZDMap.ts
+++ b/src/common/ZDMap.ts
@@ -193,7 +193,8 @@ export class ZDMap extends Map {
       settingsStore,
       this.layers,
       tags,
-      handlers
+      handlers,
+      controls
     );
     controls.addControl(this.settingsControl);
 

--- a/src/common/style.scss
+++ b/src/common/style.scss
@@ -67,6 +67,10 @@ body {
   margin-left: 0;
 }
 
+.leaflet-right .zd-controls {
+  margin-right: 0;
+}
+
 .leaflet-bottom .zd-controls {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Fixes #80

# Summary

Add options for controls position: Left (default) and Right

# Testing
- All maps have option
- Setting is persisted per-map rather than globally
- In portrait layout, controls stay at bottom.

## Screenshots
![Screenshot - Controls on Left](https://github.com/zeldadungeon/maps/assets/74829867/c23b7c27-8cd6-4346-8d3e-1ab5355a1f53)
![Screenshot - Controls on Right](https://github.com/zeldadungeon/maps/assets/74829867/10ecbfe5-2f7f-401e-8ccf-e024ee289572)

