### PR TITLE
Fix Other Travel Gate filtering

### DIFF
--- a/public/totk/markers/depths/locations.json
+++ b/public/totk/markers/depths/locations.json
@@ -439,7 +439,7 @@
         ]
     },
     {
-        "name": "Other Travel Gates",
+        "name": "Other Travel Gate",
         "source": "summary",
         "layers": [
             {

--- a/public/totk/markers/sky/locations.json
+++ b/public/totk/markers/sky/locations.json
@@ -333,7 +333,7 @@
         ]
     },
     {
-        "name": "Other Travel Gates",
+        "name": "Other Travel Gate",
         "source": "summary",
         "layers": [
             {


### PR DESCRIPTION
# Summary

Update the location name to match the legend item

If locations.json should stay plural, then I could instead update the legend item in totk.ts to be plural

# Testing
- When toggling All and None, these are included
- When toggling the specific legend item, these are included