### PR TITLE
show error indicator in popups if wiki content fails to load

### DIFF
--- a/src/common/style.scss
+++ b/src/common/style.scss
@@ -507,6 +507,11 @@ body {
   color: white;
 }
 
+.zd-popup__error-indicator {
+  text-align: center;
+  color: white;
+}
+
 .zd-popup__footer {
   text-align: center;
   font-style: italic;


### PR DESCRIPTION
# Summary
Before this change, popups would remain in the loading state with the spinning icon if the wiki fetch fails.

This change introduces `ZDPopup.loadContentFromQuery` which drives popup content management for queried data. A "query" is just a Promise that resolves to a string, and rejects if it ultimately fails. A query can make chained calls in cases of fallbacks and redirects, as long as a string is returned in the end.

# Testing
Given https://github.com/zeldadungeon/maps/issues/88 , I can't do full end-to-end testing locally. But I was able to mock out query results for a few different cases. The error screenshots are real though!

## Case: Summary
![summary-mock-response](https://github.com/zeldadungeon/maps/assets/74829867/951a1acc-1bbb-4b5b-be10-0e8e7f6c5579)
![summary-error](https://github.com/zeldadungeon/maps/assets/74829867/20e7cb53-83a1-45ce-9b87-0fcc1d6104b9)

## Case: Section
![section-mock-response](https://github.com/zeldadungeon/maps/assets/74829867/3592eb69-7c3c-41ba-ada0-d9ac9e5658a9)
![section-error](https://github.com/zeldadungeon/maps/assets/74829867/9550055b-95c1-4b5f-b55c-c12631b07451)

## Case: Page Content
![page-content-mock-response](https://github.com/zeldadungeon/maps/assets/74829867/68e56d7b-53c3-4a35-9635-2c07f6efddc1)
![page-content-error](https://github.com/zeldadungeon/maps/assets/74829867/106fdb74-7b84-48a5-9757-bd0e24857ac8)

## Case: Map Page
![map-page-mock-response](https://github.com/zeldadungeon/maps/assets/74829867/85fbdaba-d5a0-4f81-9a80-b67a4d85df03)
![map-page-error](https://github.com/zeldadungeon/maps/assets/74829867/4a5ee6b8-ee4e-4219-ba12-621c4d859cb9)