### PR TITLE
[fix #57] dim completed markers

### DIFF
--- a/src/common/ZDMarker.ts
+++ b/src/common/ZDMarker.ts
@@ -69,11 +69,7 @@ export class ZDMarker extends Marker {
         marker.complete();
       });
       marker.popup.on("uncomplete", () => {
-        const tag = marker.tags.indexOf("Completed");
-        if (tag > -1) {
-          marker.tags.splice(tag, 1);
-        }
-        marker.fire("uncompleted");
+        marker.clearCompletion();
       });
       marker.bindPopup(marker.popup);
       marker.on("popupopen", () => {
@@ -103,9 +99,19 @@ export class ZDMarker extends Marker {
     this.tileContainers.push(container);
   }
 
+  // @override
+  public setOpacity(opacity: number) {
+    super.setOpacity(opacity);
+    if (this.hasPath()) {
+      this.path?.setStyle({ opacity });
+    }
+    return this;
+  }
+
   public complete(): void {
     this.tags.push("Completed");
     this.popup?.markCompleted();
+    this.setOpacity(0.5);
     this.fire("completed");
   }
 
@@ -115,6 +121,7 @@ export class ZDMarker extends Marker {
       this.tags.splice(tag, 1);
     }
     this.popup?.markUncompleted();
+    this.setOpacity(1);
     this.fire("uncompleted");
   }
 


### PR DESCRIPTION
Fixes #57

# Summary
Set marker + path opacity to 0.5 if marker is completed.

# Testing
- Toggling completion via popup toggles opacity
- Show/Hide Completed works as expected
- Clear completion data also reverts opacity to 1
- **Due to #88 I cannot test loading completed markers from wiki**

## Screenshot
![Screenshot 2023-06-30 105743](https://github.com/zeldadungeon/maps/assets/74829867/74c939cd-0495-4bfa-a815-b0bc7cb23f96)
