### PR TITLE
Various Issue Fixes

### DIFF
--- a/public/totk/markers/sky/labels.json
+++ b/public/totk/markers/sky/labels.json
@@ -90,7 +90,6 @@
       },
       {
         "minZoom": 2,
-        "maxZoom": 3,
         "markers": [
           {
             "coords": [

--- a/public/totk/markers/surface/othermarkers.json
+++ b/public/totk/markers/surface/othermarkers.json
@@ -2238,7 +2238,7 @@
   },
   {
     "name": "Hinox",
-    "source": "summary",
+    "source": "mapns",
     "layers": [
       {
         "minZoom": 4,
@@ -2654,7 +2654,7 @@
   },
   {
     "name": "Stone Talus",
-    "source": "summary",
+    "source": "mapns",
     "layers": [
       {
         "minZoom": 4,

--- a/public/totk/markers/surface/quests.json
+++ b/public/totk/markers/surface/quests.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Dragon's Tear",
-    "source": "summary",
+    "source": "mapns",
     "layers": [
       {
         "minZoom": 1,

--- a/public/totk/markers/surface/services.json
+++ b/public/totk/markers/surface/services.json
@@ -1154,6 +1154,7 @@
   },
   {
     "name": "Great Fairy",
+    "source": "summary",
     "layers": [
       {
         "minZoom": 4,

--- a/public/totk/markers/surface/tgates.json
+++ b/public/totk/markers/surface/tgates.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Dungeon",
-    "source": "summary",
+    "source": "section",
     "layers": [
       {
         "icon": {
@@ -18,7 +18,7 @@
             "elv": 380.461395,
             "id": "LargeDungeonHyruleCastle",
             "name": "Hyrule Castle",
-            "link": "Hyrule Castle"
+            "link": "Hyrule Castle (Breath of the Wild)#Tears of the Kingdom"
           }
         ]
       },

--- a/src/common/Controls/FilterControl.ts
+++ b/src/common/Controls/FilterControl.ts
@@ -224,7 +224,7 @@ export class FilterControl extends ControlPane {
       "zd-legend__category-div",
       this.categoryList
     );
-    const icon = DomUtil.create("img", "", div);
+    const icon = DomUtil.create("img", "selectable", div);
     //Check if URL ends in .png or .svg
     if (category.iconUrl.endsWith(".svg")) {
       DomUtil.addClass(icon, "zd-legend__icon__svg");

--- a/src/totk.ts
+++ b/src/totk.ts
@@ -547,7 +547,7 @@ window.onload = async () => {
   map.addLegend(
     [
       legendItem("Hudson Sign", "hudsonsign.svg", 24, 24),
-      legendItem("Minigames", "minigame.svg", 30, 30),
+      legendItem("Minigame", "minigame.svg", 30, 30),
       legendItem("Cherry Tree", "cherry-blossom.svg", 25, 25),
     ],
     "Other"


### PR DESCRIPTION
- #73 - Removed maximum zoom level for those locations
- #109 -  Fixed bug by making labeling consistent with [the wiki page](https://www.zeldadungeon.net/wiki/Zelda_Dungeon:Tears_of_the_Kingdom_Map/Surface_Categories)
- #120 -  Made icons selectable <sup>~~I'm certain I didn't do it correctly~~</sup>
- #126 -  Fixed Hyrule Castle link (Water Temple was previously fixed at some point)
- #131 -  Fixed fairy fountains/Malanya Spring having no source (now `summary`)
- #132 -  Made Dragon Tears source from `mapns` rather than `summary` to allow for the specification of which memory is triggered/the pre-requisite for the last one
- #141 - Made hinoxes and talus source from `mapns`, allowing for location specificity, as well as weapon drops and other possible notes